### PR TITLE
Removing the target _blank when clicking the logo

### DIFF
--- a/_layouts/baloisedesign.html
+++ b/_layouts/baloisedesign.html
@@ -41,7 +41,7 @@
 <bal-app background>
 
     <bal-navbar interface="app">
-        <bal-navbar-brand href="/" target="_blank">Open Source</bal-navbar-brand>
+        <bal-navbar-brand href="/">Open Source</bal-navbar-brand>
         <bal-navbar-menu>
             <bal-navbar-menu-start></bal-navbar-menu-start>
             <bal-navbar-menu-end>


### PR DESCRIPTION
When clicking on the logo, the webpage is redirecting to a new tab, this is not really user friendly. I removed the target="_blank" to be able to go back to the homepage without opening a new tab.